### PR TITLE
Adjust 109/110 schedule milestones for EOY

### DIFF
--- a/app/classes/ReleaseInsights/Release.php
+++ b/app/classes/ReleaseInsights/Release.php
@@ -63,7 +63,8 @@ class Release
         $nightly->modify('-1 day');
 
         $x = match ($this->version) {
-            '97.0' => 4,
+            '97.0'  => 4,
+            '110.0' => 4,
             default => 3,
         };
 
@@ -83,7 +84,7 @@ class Release
             'beta_4'              => $date('Sunday'),
             'beta_5'              => $date('Tuesday'),
             'beta_6'              => $date('Thursday'),
-            'beta_7'              => $date('Sunday'),
+            'beta_7'              => $this->version === '109.0' ? $date('Sunday +1 week') : $date('Sunday'),
             'beta_8'              => $date('Tuesday'),
             'beta_9'              => $date('Thursday'),
             'rc_gtb'              => $date('Monday'),

--- a/app/views/templates/future_release.html.twig
+++ b/app/views/templates/future_release.html.twig
@@ -18,6 +18,10 @@
     {% set channel = 'future' %}
   {% endif %}
 
+{% if release == 109 %}
+  {% set alert = alert ~ ' <p class="m-0 text-danger"><span class="information bi bi-info-square-fill fs-6 align-baseline"></span> No automated betas the last week of December.</p>'%}
+{%  endif %}
+
   <div class="w-50 alert alert-primary mx-auto text-center" role="alert">{{ alert|raw }}</div>
 
   {% if channel == 'nightly' and not nightly_updates %}
@@ -110,8 +114,10 @@
   %}
 
   <table class="table table-light table-striped table-bordered table-sm w-50 justify-content-center mt-4">
-  <caption class="alert-success mx-auto text-center">Milestones</caption>
-  {% for key,value in cycle_dates %}
+  <tr>
+    <th colspan="2" class="text-center table-warning">Milestones</th>
+  </tr>
+  {% for key, value in cycle_dates %}
     {% if key != 'version' %}
       {% set extra = '' %}
 
@@ -119,11 +125,11 @@
         {% set extra = ' <small class="badge bg-warning text-dark">Draft beta release notes</small>' %}
       {% endif %}
 
-      {% if loop.revindex == 7%}
+      {% if key == 'beta_6' %}
         {% set extra = ' <small class="badge bg-warning text-dark">Early betas end</small>' %}
       {% endif %}
 
-      {% if loop.revindex == 4 %}
+      {% if key == 'beta_9' %}
         {% set extra = ' <small class="badge bg-warning text-dark">Last beta uplifts</small>' %}
       {% endif %}
 

--- a/app/views/templates/past_release.html.twig
+++ b/app/views/templates/past_release.html.twig
@@ -88,7 +88,9 @@
 
     </table>
   <table class="table table-light table-striped table-bordered table-sm w-50 justify-content-center mt-4">
-  <caption class="alert-success mx-auto text-center">Key Milestones</caption>
+    <tr>
+      <th colspan="2" class="text-center table-warning">Key Milestones</th>
+    </tr>
     <tr>
       <th>Nightly start</th>
       <td title="{{ nightly_start_date|format_date('full', locale='en') }}">{{ nightly_start_date|format_date(pattern='MMMM d', locale='en') }}</td>

--- a/tests/Unit/ReleaseInsights/ReleaseTest.php
+++ b/tests/Unit/ReleaseInsights/ReleaseTest.php
@@ -8,11 +8,16 @@ test('Release->getSchedule()', function () {
     $obj = new Release('102.0');
     expect($obj->getSchedule())
         ->toBeArray();
+    $obj = new Release('110.0');
+    expect($obj->getSchedule())
+        ->toBeArray();
+    $obj = new Release('97.0');
+    expect($obj->getSchedule())
+        ->toBeArray();
     $obj = new Release('error');
     expect($obj->getSchedule())
         ->toBeArray();
 });
-
 
 test('Release->getNiceLabel()', function () {
     expect(Release::getNiceLabel('103', 'soft_code_freeze'))


### PR DESCRIPTION
+ fix some label logic in templates
+ restyle milestone headers
+ add warning on 109 release that we don't have betas last week of the year